### PR TITLE
Correct TWRP_QSEECOMD path

### DIFF
--- a/extract-files.sh
+++ b/extract-files.sh
@@ -61,7 +61,7 @@ setup_vendor "$DEVICE_COMMON" "$VENDOR_COMMON" "$LINEAGE_ROOT" true "$CLEAN_VEND
 extract "$MY_DIR"/proprietary-files.txt "$SRC" "$SECTION"
 extract "$MY_DIR"/proprietary-files-twrp.txt "$SRC" "$SECTION"
 
-TWRP_QSEECOMD="$CM_ROOT"/vendor/"$VENDOR_COMMON"/"$DEVICE_COMMON"/proprietary/recovery/root/sbin/qseecomd
+TWRP_QSEECOMD="$LINEAGE_ROOT"/vendor/"$VENDOR_COMMON"/"$DEVICE_COMMON"/proprietary/recovery/root/sbin/qseecomd
 
 sed -i "s|/system/bin/linker|/sbin/linker\x0\x0\x0\x0\x0\x0|g" "$TWRP_QSEECOMD"
 


### PR DESCRIPTION
$CM_ROOT is a deprecated variable replaced by $LINEAGE_ROOT.
Without this commit, this script will issue a fatal error when extracting proprietary blobs from LineageOS zip file.